### PR TITLE
Fix GPG signing process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ jobs:
               with:
                   java-version: 8
 
+            - name: Prepare release
+              run: |
+                  export GPG_TTY=$(tty)
+
             - name: Release Maven package
               uses: samuelmeuli/action-maven-publish@v1
               with:
@@ -63,6 +67,7 @@ jobs:
                       -v "$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0" -t \
                       -m '/pom:project/pom:version' -v . -n pom_tmp.xml)-SNAPSHOT" pom_tmp.xml > pom.xml
                   rm -f pom_tmp.xml
+                  export GPG_TTY=$(tty)
 
             - name: Release Maven package
               uses: samuelmeuli/action-maven-publish@v1


### PR DESCRIPTION
### Description
Fixes failing deployment to Maven central due to:
```
gpg: signing failed: Inappropriate ioctl for device
gpg: signing failed: Inappropriate ioctl for device
```

### Issue relations
Fixes #9 

### Test Scenarios
Check if the develop deployment now passes. Artifact should be deployed properly to Maven central.
