### PR TITLE
Fetch tags during release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
               run: |
                   current_version=$(xmlstarlet sel -N pom="http://maven.apache.org/POM/4.0.0" -t \
                       -m '/pom:project/pom:version' -v . -n pom.xml)
-                  git fetch --all
+                  git fetch --all --tags --force
                   git tag -a v${current_version} -m "Release version ${current_version}"
                   git push origin v${current_version}
                   plain_version_env="::set-env name=CURRENT_PROJECT_VERSION::$current_version"


### PR DESCRIPTION
### Description
Fetch all tags during release. If not done, the changelog cannot be build correcly

### Issue relations
Resolves #39 

### Test Scenarios
 - Check after the next release if the changelog contains more content than the tag name of the current release.
